### PR TITLE
fix($getFilterMethod): prevent camelCase from stripping the leading $ of filter name

### DIFF
--- a/src/base_model.ts
+++ b/src/base_model.ts
@@ -72,7 +72,11 @@ export class BaseModelFilter implements LucidFilter {
 
   $getFilterMethod(key: string): string {
     const methodName = this.constructor.dropId ? key.replace(/^(.*)(_id|Id)$/, '$1') : key
-    return this.constructor.camelCase ? camelCase(methodName) : methodName
+    return this.constructor.camelCase
+      ? methodName.charAt(0) === '$'
+        ? `$${camelCase(methodName)}`
+        : camelCase(methodName)
+      : methodName
   }
 
   static removeEmptyInput(input: object): object {

--- a/tests/filters/test_model_filter.ts
+++ b/tests/filters/test_model_filter.ts
@@ -43,4 +43,8 @@ export default class TestModelFilter extends BaseModelFilter {
   mobilePhone(value: string) {
     console.log(value)
   }
+
+  $select(value: string | string[]): void {
+    this.$query.select(Array.isArray(value) ? value : [value])
+  }
 }

--- a/tests/unit/filter.spec.ts
+++ b/tests/unit/filter.spec.ts
@@ -89,6 +89,10 @@ test.group('BaseModelFilter', (group) => {
     const companyUsersWithoutId = await User.filter({ company: 2 }, TestModelFilter).exec()
     assert.lengthOf(companyUsers, 1)
     assert.lengthOf(companyUsersWithoutId, companyUsers.length)
+
+    const selected = await User.filter({ $select: ['username', 'email'] }, TestModelFilter).first()
+    assert.properties(selected!.toJSON(), ['username', 'email'])
+    assert.notAllProperties(selected!.toJSON(), ['isAdmin', 'companyId'])
   })
 
   test('filter model through filtration scope', async ({ assert }) => {

--- a/tests/unit/model.spec.ts
+++ b/tests/unit/model.spec.ts
@@ -73,6 +73,18 @@ test.group('ModelFilter', () => {
     assert.strictEqual(userFilter.$getFilterMethod('companyId'), 'companyId')
   })
 
+  test('get filter method name starting with $', ({ assert }) => {
+    class User extends BaseModel {}
+    User.boot()
+
+    class UserFilter extends BaseModelFilter {
+      static dropId: boolean = false
+    }
+
+    const userFilter = new UserFilter(User.query(), {})
+    assert.strictEqual(userFilter.$getFilterMethod('$select'), '$select')
+  })
+
   test('whitelist method and method is callable', ({ assert }) => {
     class User extends BaseModel {}
     User.boot()


### PR DESCRIPTION
Hi, 

I was trying to implement special filters starting with a $ chat (`$select`, `$sort`). And while testing i encountered an issue, `$getFilterMethod` strip the leading $ of the filter name while calling `lodash/camelCase`. This PR fixes it and allow the use of $filters  