### PR TITLE
feat: add AdonisJS v7 compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 package-lock = false
+onlyBuiltDependencies:
+  - better-sqlite3

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+import { configPkg } from '@adonisjs/eslint-config'
+
+export default configPkg()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Addon for filtering AdonisJS Lucid ORM",
   "version": "5.2.0",
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=22.0.0"
   },
   "main": "./build/index.js",
   "type": "module",
@@ -20,7 +20,7 @@
     "./provider": "./build/providers/lucid_filter_provider.js"
   },
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint",
     "clean": "del-cli build",
     "precompile": "npm run lint && npm run clean",
     "postcompile": "npm run copy:stubs && npm run index:commands",
@@ -28,7 +28,7 @@
     "build": "npm run compile",
     "copy:stubs": "copyfiles \"stubs/**/**/*.stub\" --up=\"1\" build",
     "index:commands": "adonis-kit index build/commands",
-    "quick:test": "NODE_DEBUG=\"adonis-lucid-filter\" node --enable-source-maps --loader=ts-node/esm bin/test.ts",
+    "quick:test": "node --enable-source-maps --import=@poppinss/ts-exec bin/test.ts",
     "pretest": "npm run lint",
     "test": "c8 npm run quick:test",
     "typecheck": "tsc --noEmit",
@@ -37,39 +37,40 @@
     "release": "np"
   },
   "devDependencies": {
-    "@adonisjs/assembler": "^7.7.0",
-    "@adonisjs/core": "^6.12.1",
-    "@adonisjs/eslint-config": "^1.3.0",
-    "@adonisjs/lucid": "^21.1.0",
-    "@adonisjs/prettier-config": "^1.3.0",
-    "@adonisjs/tsconfig": "^1.3.0",
-    "@japa/assert": "^2.1.0",
-    "@japa/expect-type": "^2.0.2",
-    "@japa/file-system": "^2.3.0",
-    "@japa/runner": "^3.1.4",
-    "@japa/snapshot": "^2.0.5",
-    "@swc/core": "^1.6.7",
+    "@adonisjs/assembler": "^8.0.0",
+    "@adonisjs/core": "^7.0.1",
+    "@adonisjs/eslint-config": "^3.0.0",
+    "@adonisjs/lucid": "^22.0.0",
+    "@adonisjs/prettier-config": "^1.4.5",
+    "@adonisjs/tsconfig": "^2.0.0",
+    "@japa/assert": "^4.2.0",
+    "@japa/expect-type": "^2.0.4",
+    "@japa/file-system": "^3.0.0",
+    "@japa/runner": "^5.3.0",
+    "@japa/snapshot": "^2.0.10",
+    "@poppinss/ts-exec": "^1.4.4",
     "@types/lodash": "^4.17.6",
-    "c8": "^9.1.0",
+    "@types/node": "^22.0.0",
+    "better-sqlite3": "^12.6.2",
+    "c8": "^11.0.0",
     "copyfiles": "^2.4.1",
-    "del-cli": "^5.1.0",
-    "eslint": "^8.57.0",
+    "del-cli": "^7.0.0",
+    "eslint": "^10.0.0",
     "knex": "^3.1.0",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",
     "np": "^9.2.0",
     "reflect-metadata": "^0.2.2",
-    "sqlite3": "^5.1.7",
-    "ts-node": "^10.9.2",
     "tsup": "^8.1.0",
-    "typescript": "^5.5.3"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@poppinss/hooks": "^7.3.0",
     "type-fest": "^4.21.0"
   },
   "peerDependencies": {
-    "@adonisjs/core": "^6.2.3",
-    "@adonisjs/lucid": "^21.1.0",
+    "@adonisjs/core": "^6.2.3 || ^7.0.0",
+    "@adonisjs/lucid": "^21.1.0 || ^22.0.0",
     "lodash": "^4.17.21"
   },
   "author": "LookinGit",
@@ -90,11 +91,9 @@
     "adonis",
     "adonis-lucid",
     "adonis-filter",
-    "adonis-lucid-filter"
+    "adonis-lucid-filter",
+    "adonisjs-v7"
   ],
-  "eslintConfig": {
-    "extends": "@adonisjs/eslint-config/package"
-  },
   "prettier": "@adonisjs/prettier-config",
   "publishConfig": {
     "access": "public",

--- a/src/base_model.ts
+++ b/src/base_model.ts
@@ -36,7 +36,7 @@ export class BaseModelFilter implements LucidFilter {
     public $input: object
   ) {
     this.$input = BaseModelFilter.removeEmptyInput(this.$input)
-    this.$blacklist = this.constructor.blacklist
+    this.$blacklist = [...this.constructor.blacklist]
   }
 
   handle(): any {

--- a/stubs/main.ts
+++ b/stubs/main.ts
@@ -7,6 +7,4 @@
  * file that was distributed with this source code.
  */
 
-import { getDirname } from '@poppinss/utils'
-
-export const stubsRoot = getDirname(import.meta.url)
+export const stubsRoot = import.meta.dirname

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -33,7 +33,7 @@ export async function createDatabase() {
       connection: process.env.DB || 'sqlite',
       connections: {
         sqlite: {
-          client: 'sqlite3',
+          client: 'better-sqlite3',
           connection: {
             filename: join(test.context.fs.basePath, 'db.sqlite3'),
           },


### PR DESCRIPTION
I've been using this package in production and needed AdonisJS v7 support, so I've done the migration work.

## Changes

- Update peerDependencies to support both `@adonisjs/core ^6 || ^7` and `@adonisjs/lucid ^21 || ^22`
- Update all devDependencies to latest versions (Japa 5, ESLint 10, TypeScript 5.9)
- Replace deprecated `sqlite3` with `better-sqlite3` for tests
- Replace `ts-node` with `@poppinss/ts-exec` for test runner
- Use `import.meta.dirname` instead of `getDirname` (Node 22+)
- Add `@poppinss/hooks` as dependency
- Migrate to ESLint flat config
- Fix blacklist mutation bug: copy array instead of sharing static reference
- Bump minimum Node version to 22 (aligned with AdonisJS v7)

If you're still actively maintaining this package, I'd love to see this merged. Otherwise, I'm happy to continue maintaining a fork under `@dirupt/adonis-lucid-filter` (already published on npm).